### PR TITLE
Fix contact modal closing and permissions

### DIFF
--- a/admin/js/wp-sms-voipms-admin.js
+++ b/admin/js/wp-sms-voipms-admin.js
@@ -36,8 +36,8 @@
         // Vérifier le hash URL pour activer l'onglet approprié
         checkUrlHash();
         
-        // Rafraîchir la liste des contacts toutes les 30 secondes
-        setInterval(refreshContactsList, 30000);
+        // Rafraîchir la liste des contacts uniquement sur demande
+        // setInterval(refreshContactsList, 30000);
     });
     
     /**
@@ -115,8 +115,8 @@
             $('#new-conversation-modal').show();
         });
         
-        // Fermer les modales
-        $('.wp-sms-voipms-modal-close').on('click', function() {
+        // Fermer les modales (icône "X")
+        $('.modal-close, .wp-sms-voipms-modal-close').on('click', function() {
             $(this).closest('.wp-sms-voipms-modal').hide();
         });
         

--- a/admin/partials/wp-sms-voipms-admin-contacts.php
+++ b/admin/partials/wp-sms-voipms-admin-contacts.php
@@ -235,14 +235,18 @@ jQuery(document).ready(function($) {
             },
             error: function(xhr) {
                 var errorMsg = '';
-                
-                try {
-                    var response = JSON.parse(xhr.responseText);
-                    errorMsg = response.message || '<?php _e('Erreur lors de l\'enregistrement du contact.', 'wp-sms-voipms'); ?>';
-                } catch (e) {
-                    errorMsg = '<?php _e('Erreur lors de l\'enregistrement du contact.', 'wp-sms-voipms'); ?>';
+
+                if (xhr.status === 403) {
+                    errorMsg = '<?php _e('Vous n\'avez pas la permission d\'ajouter des contacts.', 'wp-sms-voipms'); ?>';
+                } else {
+                    try {
+                        var response = JSON.parse(xhr.responseText);
+                        errorMsg = response.message || '<?php _e('Erreur lors de l\'enregistrement du contact.', 'wp-sms-voipms'); ?>';
+                    } catch (e) {
+                        errorMsg = '<?php _e('Erreur lors de l\'enregistrement du contact.', 'wp-sms-voipms'); ?>';
+                    }
                 }
-                
+
                 alert(errorMsg);
             }
         });

--- a/includes/class-wp-sms-voipms-rest-api.php
+++ b/includes/class-wp-sms-voipms-rest-api.php
@@ -63,7 +63,7 @@ class Wp_Sms_Voipms_Rest_Api {
             array(
                 'methods'  => 'POST',
                 'callback' => array($this, 'create_contact'),
-                'permission_callback' => array($this, 'manage_settings_permissions_check'),
+                'permission_callback' => array($this, 'send_sms_permissions_check'),
             ),
         ));
 
@@ -76,12 +76,12 @@ class Wp_Sms_Voipms_Rest_Api {
             array(
                 'methods'  => 'PUT',
                 'callback' => array($this, 'update_contact'),
-                'permission_callback' => array($this, 'manage_settings_permissions_check'),
+                'permission_callback' => array($this, 'send_sms_permissions_check'),
             ),
             array(
                 'methods'  => 'DELETE',
                 'callback' => array($this, 'delete_contact'),
-                'permission_callback' => array($this, 'manage_settings_permissions_check'),
+                'permission_callback' => array($this, 'send_sms_permissions_check'),
             ),
         ));
     }

--- a/public/js/wp-sms-voipms-public.js
+++ b/public/js/wp-sms-voipms-public.js
@@ -32,8 +32,8 @@
         initializeMessageForm();
         initializeModals();
         
-        // Rafraîchir la liste des contacts périodiquement
-        setInterval(refreshContactsList, 30000);
+        // Rafraîchir la liste des contacts uniquement sur demande
+        // setInterval(refreshContactsList, 30000);
     });
     
     /**
@@ -79,8 +79,8 @@
             $('#new-conversation-modal').show();
         });
         
-        // Fermer les modales
-        $('.wp-sms-voipms-modal-close').on('click', function() {
+        // Fermer les modales (icône "X")
+        $('.modal-close, .wp-sms-voipms-modal-close').on('click', function() {
             $(this).closest('.wp-sms-voipms-modal').hide();
         });
         


### PR DESCRIPTION
## Summary
- fix close button selector
- stop automatic contact scanning
- allow regular users to create/update/delete contacts
- display permission error when adding contacts without capability

## Testing
- `node -v`