### PR TITLE
Fix nonce for REST requests

### DIFF
--- a/admin/class-wp-sms-voipms-admin.php
+++ b/admin/class-wp-sms-voipms-admin.php
@@ -40,10 +40,12 @@ class Wp_Sms_Voipms_Admin {
         
         // Ajouter les variables locales pour le script
         wp_localize_script($this->plugin_name, 'wp_sms_voipms', array(
-            'ajax_url' => admin_url('admin-ajax.php'),
-            'nonce' => wp_create_nonce('wp_sms_voipms_nonce'),
+            'ajax_url'   => admin_url('admin-ajax.php'),
+            // Utiliser le nonce par défaut de l’API REST pour éviter l’erreur
+            // "La vérification du cookie a échoué" lors des requêtes AJAX.
+            'nonce'      => wp_create_nonce('wp_rest'),
             'default_did' => get_option('wp_sms_voipms_did'),
-            'rest_url' => rest_url('wp-sms-voipms/v1/')
+            'rest_url'   => rest_url('wp-sms-voipms/v1/')
         ));
     }
 

--- a/public/class-wp-sms-voipms-public.php
+++ b/public/class-wp-sms-voipms-public.php
@@ -57,7 +57,8 @@ class Wp_Sms_Voipms_Public {
         // Ajouter les variables locales pour le script
         wp_localize_script($this->plugin_name, 'wp_sms_voipms', array(
             'ajax_url' => admin_url('admin-ajax.php'),
-            'nonce' => wp_create_nonce('wp_sms_voipms_nonce'),
+            // Utiliser le nonce WP REST pour les requêtes AJAX.
+            'nonce' => wp_create_nonce('wp_rest'),
             'rest_url' => rest_url('wp-sms-voipms/v1/'),
             'current_user_id' => get_current_user_id(),
             'loading_messages' => __('Chargement des messages...', 'wp-sms-voipms'),

--- a/public/class-wp-sms-voipms-shortcodes.php
+++ b/public/class-wp-sms-voipms-shortcodes.php
@@ -43,7 +43,9 @@ class Wp_Sms_Voipms_Shortcodes {
         // Ajouter les variables locales pour le script
         wp_localize_script($this->plugin_name, 'wp_sms_voipms', array(
             'ajax_url' => admin_url('admin-ajax.php'),
-            'nonce' => wp_create_nonce('wp_sms_voipms_nonce'),
+            // Utiliser le nonce WP REST pour éviter les erreurs d'authentification
+            // lors des appels à la REST API depuis le shortcode.
+            'nonce' => wp_create_nonce('wp_rest'),
             'rest_url' => rest_url('wp-sms-voipms/v1/'),
             'current_user_id' => get_current_user_id(),
             'platform_name' => get_option('wp_sms_voipms_platform_name', 'WP SMS VoIPms'),


### PR DESCRIPTION
## Summary
- use standard `wp_rest` nonce when localizing scripts for REST calls

## Testing
- `git status --short`
