### PR TITLE
Apply security and stability fixes

### DIFF
--- a/admin/class-wp-sms-voipms-admin.php
+++ b/admin/class-wp-sms-voipms-admin.php
@@ -209,16 +209,23 @@ class Wp_Sms_Voipms_Admin {
      * Crypter le mot de passe API avant enregistrement.
      */
     public function encrypt_api_password($password) {
-        if (!empty($password)) {
-            $key = defined('AUTH_KEY') ? AUTH_KEY : wp_salt('auth');
-            $iv  = substr(hash('sha256', $key), 0, 16);
-            $encrypted = openssl_encrypt($password, 'AES-256-CBC', $key, 0, $iv);
-            if ($encrypted) {
-                return 'enc::' . base64_encode($encrypted);
-            }
+        if (empty($password)) {
+            return get_option('wp_sms_voipms_api_password');
+        }
+
+        if (strpos($password, 'enc::') === 0) {
             return $password;
         }
-        return get_option('wp_sms_voipms_api_password');
+
+        $key = defined('AUTH_KEY') ? AUTH_KEY : wp_salt('auth');
+        $iv  = openssl_random_pseudo_bytes(16);
+        $encrypted = openssl_encrypt($password, 'AES-256-CBC', $key, 0, $iv);
+
+        if ($encrypted) {
+            return 'enc::' . base64_encode($iv) . '::' . base64_encode($encrypted);
+        }
+
+        return $password;
     }
     
     /**

--- a/admin/js/wp-sms-voipms-admin.js
+++ b/admin/js/wp-sms-voipms-admin.js
@@ -4,6 +4,11 @@
 (function($) {
     'use strict';
 
+    if (typeof window.wp_sms_voipms === 'undefined') {
+        console.error('wp_sms_voipms object is missing');
+        return;
+    }
+
     function escapeHtml(str) {
         return $('<div>').text(str).html();
     }

--- a/admin/partials/wp-sms-voipms-admin-settings.php
+++ b/admin/partials/wp-sms-voipms-admin-settings.php
@@ -39,7 +39,7 @@ if (!defined('WPINC')) {
                     <tr valign="top">
                         <th scope="row"><?php _e('Mot de passe API', 'wp-sms-voipms'); ?></th>
                         <td>
-                            <input type="password" name="wp_sms_voipms_api_password" value="<?php echo esc_attr(get_option('wp_sms_voipms_api_password')); ?>" class="regular-text" />
+                            <input type="password" name="wp_sms_voipms_api_password" class="regular-text" autocomplete="new-password" />
                             <p class="description"><?php _e('Votre mot de passe VoIP.ms', 'wp-sms-voipms'); ?></p>
                         </td>
                     </tr>

--- a/includes/class-wp-sms-voipms.php
+++ b/includes/class-wp-sms-voipms.php
@@ -81,7 +81,7 @@ class Wp_Sms_Voipms {
      * Définir les hooks liés à la partie admin du plugin.
      */
     private function define_admin_hooks() {
-        $plugin_admin = new Wp_Sms_Voipms_Admin($this->get_plugin_name(), $this->get_version());
+        $plugin_admin = new Wp_Sms_Voipms_Admin($this->get_plugin_name() . '-admin', $this->get_version());
 
         // Ajouter les menus d'administration
         $this->loader->add_action('admin_menu', $plugin_admin, 'add_plugin_menu');
@@ -104,7 +104,7 @@ class Wp_Sms_Voipms {
      * Définir les hooks liés à la partie publique du plugin.
      */
     private function define_public_hooks() {
-        $plugin_public = new Wp_Sms_Voipms_Public($this->get_plugin_name(), $this->get_version());
+        $plugin_public = new Wp_Sms_Voipms_Public($this->get_plugin_name() . '-public', $this->get_version());
 
         // Ajouter les scripts et styles
         $this->loader->add_action('wp_enqueue_scripts', $plugin_public, 'enqueue_styles');
@@ -115,7 +115,7 @@ class Wp_Sms_Voipms {
      * Définir les shortcodes.
      */
     private function define_shortcodes() {
-        $plugin_shortcodes = new Wp_Sms_Voipms_Shortcodes($this->get_plugin_name(), $this->get_version());
+        $plugin_shortcodes = new Wp_Sms_Voipms_Shortcodes($this->get_plugin_name() . '-public', $this->get_version());
         
         // Enregistrer les shortcodes
         add_shortcode('voipms_sms_interface', array($plugin_shortcodes, 'sms_interface_shortcode'));

--- a/public/js/wp-sms-voipms-public.js
+++ b/public/js/wp-sms-voipms-public.js
@@ -4,6 +4,11 @@
 (function($) {
     'use strict';
 
+    if (typeof window.wp_sms_voipms === 'undefined') {
+        console.error('wp_sms_voipms object is missing');
+        return;
+    }
+
     function escapeHtml(str) {
         return $('<div>').text(str).html();
     }


### PR DESCRIPTION
## Summary
- randomize IV for API password encryption and avoid double encryption
- leave API password field blank by default
- prevent errors if script data isn't localized
- use unique handles for admin and public assets

## Testing
- `npm test` *(fails: package.json missing)*
- `composer test` *(fails: command not found)*