### PR TITLE
Add CSS styles for error and empty states

### DIFF
--- a/public/css/wp-sms-voipms-public.css
+++ b/public/css/wp-sms-voipms-public.css
@@ -328,6 +328,17 @@
     padding: 20px;
     color: var(--secondary-color);
 }
+.wp-sms-voipms-error {
+    color: var(--danger-color);
+    text-align: center;
+    padding: 20px;
+}
+.wp-sms-voipms-empty-list {
+    color: var(--secondary-color);
+    text-align: center;
+    padding: 20px;
+}
+
 
 /* Responsive */
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- style error and empty state placeholders in the public interface

## Testing
- `php -l wp-sms-voipms.php` *(fails: `php` not installed)*