### PR TITLE
Fix contact creation validation

### DIFF
--- a/admin/partials/wp-sms-voipms-admin-contacts.php
+++ b/admin/partials/wp-sms-voipms-admin-contacts.php
@@ -232,12 +232,11 @@ jQuery(document).ready(function($) {
                 if (xhr.status === 403) {
                     errorMsg = '<?php _e('Vous n\'avez pas la permission d\'ajouter des contacts.', 'wp-sms-voipms'); ?>';
                 } else {
-                    try {
-                        var response = JSON.parse(xhr.responseText);
-                        errorMsg = response.message || '<?php _e('Erreur lors de l\'enregistrement du contact.', 'wp-sms-voipms'); ?>';
-                    } catch (e) {
-                        errorMsg = '<?php _e('Erreur lors de l\'enregistrement du contact.', 'wp-sms-voipms'); ?>';
+                    var response = xhr.responseJSON;
+                    if (!response) {
+                        try { response = JSON.parse(xhr.responseText); } catch (e) { response = {}; }
                     }
+                    errorMsg = (response && response.message) ? response.message : '<?php _e('Erreur lors de l\'enregistrement du contact.', 'wp-sms-voipms'); ?>';
                 }
 
                 alert(errorMsg);

--- a/class-wp-sms-voipms-rest-api.php
+++ b/class-wp-sms-voipms-rest-api.php
@@ -337,7 +337,15 @@ class Wp_Sms_Voipms_Rest_Api {
             return new WP_Error('missing_parameters', __('Numéro et nom requis.', 'wp-sms-voipms'), array('status' => 400));
         }
 
+        if (strlen($phone) < 10) {
+            return new WP_Error('invalid_phone', __('Numéro de téléphone invalide.', 'wp-sms-voipms'), array('status' => 400));
+        }
+
         $table = $wpdb->prefix . 'voipms_sms_contacts';
+        $exists = $wpdb->get_var($wpdb->prepare("SELECT id FROM $table WHERE phone_number = %s AND user_id = %d", $phone, $user_id));
+        if ($exists) {
+            return new WP_Error('contact_exists', __('Ce contact existe déjà.', 'wp-sms-voipms'), array('status' => 409));
+        }
         $result = $wpdb->insert(
             $table,
             array(

--- a/includes/class-wp-sms-voipms-rest-api.php
+++ b/includes/class-wp-sms-voipms-rest-api.php
@@ -337,7 +337,15 @@ class Wp_Sms_Voipms_Rest_Api {
             return new WP_Error('missing_parameters', __('Numéro et nom requis.', 'wp-sms-voipms'), array('status' => 400));
         }
 
+        if (strlen($phone) < 10) {
+            return new WP_Error('invalid_phone', __('Numéro de téléphone invalide.', 'wp-sms-voipms'), array('status' => 400));
+        }
+
         $table = $wpdb->prefix . 'voipms_sms_contacts';
+        $exists = $wpdb->get_var($wpdb->prepare("SELECT id FROM $table WHERE phone_number = %s AND user_id = %d", $phone, $user_id));
+        if ($exists) {
+            return new WP_Error('contact_exists', __('Ce contact existe déjà.', 'wp-sms-voipms'), array('status' => 409));
+        }
         $result = $wpdb->insert(
             $table,
             array(

--- a/partials/wp-sms-voipms-admin-contacts.php
+++ b/partials/wp-sms-voipms-admin-contacts.php
@@ -232,12 +232,11 @@ jQuery(document).ready(function($) {
                 if (xhr.status === 403) {
                     errorMsg = '<?php _e('Vous n\'avez pas la permission d\'ajouter des contacts.', 'wp-sms-voipms'); ?>';
                 } else {
-                    try {
-                        var response = JSON.parse(xhr.responseText);
-                        errorMsg = response.message || '<?php _e('Erreur lors de l\'enregistrement du contact.', 'wp-sms-voipms'); ?>';
-                    } catch (e) {
-                        errorMsg = '<?php _e('Erreur lors de l\'enregistrement du contact.', 'wp-sms-voipms'); ?>';
+                    var response = xhr.responseJSON;
+                    if (!response) {
+                        try { response = JSON.parse(xhr.responseText); } catch (e) { response = {}; }
                     }
+                    errorMsg = (response && response.message) ? response.message : '<?php _e('Erreur lors de l\'enregistrement du contact.', 'wp-sms-voipms'); ?>';
                 }
 
                 alert(errorMsg);

--- a/wp-sms-voipms-admin-contacts.php
+++ b/wp-sms-voipms-admin-contacts.php
@@ -232,12 +232,11 @@ jQuery(document).ready(function($) {
                 if (xhr.status === 403) {
                     errorMsg = '<?php _e('Vous n\'avez pas la permission d\'ajouter des contacts.', 'wp-sms-voipms'); ?>';
                 } else {
-                    try {
-                        var response = JSON.parse(xhr.responseText);
-                        errorMsg = response.message || '<?php _e('Erreur lors de l\'enregistrement du contact.', 'wp-sms-voipms'); ?>';
-                    } catch (e) {
-                        errorMsg = '<?php _e('Erreur lors de l\'enregistrement du contact.', 'wp-sms-voipms'); ?>';
+                    var response = xhr.responseJSON;
+                    if (!response) {
+                        try { response = JSON.parse(xhr.responseText); } catch (e) { response = {}; }
                     }
+                    errorMsg = (response && response.message) ? response.message : '<?php _e('Erreur lors de l\'enregistrement du contact.', 'wp-sms-voipms'); ?>';
                 }
 
                 alert(errorMsg);


### PR DESCRIPTION
## Summary
- validate phone number and duplicate contacts before DB insert
- show REST error messages when saving contacts in the admin UI

## Testing
- `php -l includes/class-wp-sms-voipms-rest-api.php` *(fails: `php: command not found`)*